### PR TITLE
Render method on the end

### DIFF
--- a/eslint-config-feedzai-react/rules/react.js
+++ b/eslint-config-feedzai-react/rules/react.js
@@ -129,16 +129,16 @@ module.exports = {
                 "static-methods",
                 "lifecycle",
                 "event-handlers",
-                "rendering",
-                "everything-else"
+                "everything-else",
+                "rendering"
             ],
             "groups": {
                 "event-handlers": [
                     "/^_?on.+$/"
                 ],
                 "rendering": [
-                    "render",
-                    "/^_?render.+$/"
+                    "/^_?render.+$/",
+                    "render"
                 ]
             }
         }]


### PR DESCRIPTION
It is a good practice in the react community to have the `render` at the end of the file and to have any other render methods just above it. 

This commit changes the order expect to match that rule.