### PR TITLE
Forces a new line line in multiline jsx

### DIFF
--- a/eslint-config-feedzai-react/rules/react.js
+++ b/eslint-config-feedzai-react/rules/react.js
@@ -115,7 +115,6 @@ module.exports = {
         "react/jsx-pascal-case": "error",
 
         // Prevent missing parentheses around multiline JSX
-        "react/jsx-wrap-multilines": "error",
         "react/jsx-wrap-multilines": ["error", {
             "declaration": "parens-new-line",
             "assignment": "parens-new-line",

--- a/eslint-config-feedzai-react/rules/react.js
+++ b/eslint-config-feedzai-react/rules/react.js
@@ -116,6 +116,15 @@ module.exports = {
 
         // Prevent missing parentheses around multiline JSX
         "react/jsx-wrap-multilines": "error",
+        "react/jsx-wrap-multilines": ["error", {
+            "declaration": "parens-new-line",
+            "assignment": "parens-new-line",
+            "return": "parens-new-line",
+            "arrow": "parens-new-line",
+            "condition": "parens-new-line",
+            "logical": "parens-new-line",
+            "prop": "parens-new-line"
+        }],
 
         // /!\ Prevent usage of the return value of React.render
         "react/no-render-return-value": "warn",


### PR DESCRIPTION
This no longer allows this:

```
return (<div>
    bob
</div>);
```

And will only allow this:
```
return (
    <div>
        bob
    </div>
);
```

This applies not only to returns but to variable declarations as well.