### PR TITLE
Add more rules in styles, es6 and react

### DIFF
--- a/eslint-config-feedzai-react/rules/react.js
+++ b/eslint-config-feedzai-react/rules/react.js
@@ -172,10 +172,6 @@ module.exports = {
         // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-closing-bracket-location.md
         "react/jsx-closing-bracket-location": ["error", "line-aligned"],
 
-        // Enforce boolean attributes notation in JSX
-        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-boolean-value.md
-        "react/jsx-boolean-value": ["error", "never", { always: [] }],
-
         // Require that the first prop in a JSX element be on a new line when the element is multiline
         // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-first-prop-new-line.md
         "react/jsx-first-prop-new-line": ["error", "multiline-multiprop"]

--- a/eslint-config-feedzai-react/rules/react.js
+++ b/eslint-config-feedzai-react/rules/react.js
@@ -149,7 +149,36 @@ module.exports = {
                     "render"
                 ]
             }
-        }]
+        }],
+
+        // Prevent using this.state within a this.setState
+        "react/no-access-state-in-setstate": "error",
+
+        // Prevent usage of .bind() in JSX props
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-bind.md
+        "react/jsx-no-bind": ["warn", {
+            ignoreRefs: true,
+            allowArrowFunctions: true,
+            allowFunctions: false,
+            allowBind: false,
+            ignoreDOMComponents: true
+        }],
+
+        // Prevent extra closing tags for components without children
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/self-closing-comp.md
+        "react/self-closing-comp": "error",
+
+        // Validate closing bracket location in JSX
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-closing-bracket-location.md
+        "react/jsx-closing-bracket-location": ["error", "line-aligned"],
+
+        // Enforce boolean attributes notation in JSX
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-boolean-value.md
+        "react/jsx-boolean-value": ["error", "never", { always: [] }],
+
+        // Require that the first prop in a JSX element be on a new line when the element is multiline
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-first-prop-new-line.md
+        "react/jsx-first-prop-new-line": ["error", "multiline-multiprop"]
     },
 
     settings: {

--- a/eslint-config-feedzai/rules/es6.js
+++ b/eslint-config-feedzai/rules/es6.js
@@ -63,6 +63,18 @@ module.exports = {
         "template-curly-spacing": "error",
 
         // /!\ Disallow template literal placeholder syntax in regular strings
-        "no-template-curly-in-string": "warn"
+        "no-template-curly-in-string": "warn",
+
+        // require method and property shorthand syntax for object literals
+        // https://eslint.org/docs/rules/object-shorthand
+        "object-shorthand": ["error", "always", {
+            ignoreConstructors: false,
+            avoidQuotes: true
+        }],
+
+        // disallow importing from the same path more than once
+        // https://eslint.org/docs/rules/no-duplicate-imports
+        // replaced by https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-duplicates.md
+        "no-duplicate-imports": "off"
     }
 };

--- a/eslint-config-feedzai/rules/es6.js
+++ b/eslint-config-feedzai/rules/es6.js
@@ -65,13 +65,6 @@ module.exports = {
         // /!\ Disallow template literal placeholder syntax in regular strings
         "no-template-curly-in-string": "warn",
 
-        // require method and property shorthand syntax for object literals
-        // https://eslint.org/docs/rules/object-shorthand
-        "object-shorthand": ["error", "always", {
-            ignoreConstructors: false,
-            avoidQuotes: true
-        }],
-
         // disallow importing from the same path more than once
         // https://eslint.org/docs/rules/no-duplicate-imports
         // replaced by https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-duplicates.md

--- a/eslint-config-feedzai/rules/style.js
+++ b/eslint-config-feedzai/rules/style.js
@@ -165,6 +165,24 @@ module.exports = {
         "object-curly-spacing": ["error", "always"],
 
         // Don't allow multiple new lines
-        "no-multiple-empty-lines": ["error"]
+        "no-multiple-empty-lines": ["error"],
+
+        // Requires operator at the beginning of the line in multiline statements
+        // https://eslint.org/docs/rules/operator-linebreak
+        "operator-linebreak": ["error", "before", { overrides: { "=": "none" } }],
+
+        // enforce consistent line breaks inside function parentheses
+        // https://eslint.org/docs/rules/function-paren-newline
+        "function-paren-newline": ["error", "consistent"],
+
+        // disallow padding within blocks
+        "padded-blocks": ["error", { blocks: "never", classes: "never", switches: "never" }],
+
+        // require or disallow space before blocks
+        "space-before-blocks": "error",
+
+        // Enforce the location of arrow function bodies with implicit returns
+        // https://eslint.org/docs/rules/implicit-arrow-linebreak
+        "implicit-arrow-linebreak": ["error", "beside"]
     }
 };


### PR DESCRIPTION
With the increase number of frontend developers and projects at feedzai, we need to have more rules to keep the projects consistent. 

I have added the following:
[react/no-access-state-in-setstate](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-access-state-in-setstate.md)
[react/jsx-no-bind](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-bind.md)
[react/self-closing-comp](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/self-closing-comp.md)
[react/jsx-closing-bracket-location](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-closing-bracket-location.md)
[react/jsx-boolean-value](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-boolean-value.md)
[react/jsx-first-prop-new-line](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-first-prop-new-line.md)
[object-shorthand](https://eslint.org/docs/rules/object-shorthand)
[no-duplicate-imports](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-duplicates.md)
[operator-linebreak](https://eslint.org/docs/rules/operator-linebreak)
[function-paren-newline](https://eslint.org/docs/rules/function-paren-newline)
[padded-blocks](https://eslint.org/docs/rules/padded-blocks)
[space-before-blocks](https://eslint.org/docs/rules/space-before-blocks)
[implicit-arrow-linebreak](https://eslint.org/docs/rules/implicit-arrow-linebreak)