### PR TITLE
Fix wrong description for rule react/jsx-no-undef

### DIFF
--- a/eslint-config-feedzai-react/rules/react.js
+++ b/eslint-config-feedzai-react/rules/react.js
@@ -70,7 +70,7 @@ module.exports = {
         // Prevent duplicate properties in JSX
         "react/jsx-no-duplicate-props": "error",
 
-        // Prevent duplicate properties in JSX
+        // Prevent undeclared variables in JSX
         "react/jsx-no-undef": "error",
 
         // Prevent React to be incorrectly marked as unused


### PR DESCRIPTION
The current description for react/jsx-no-undef rule is wrong (it is the same as react/jsx-no-duplicate-props). 

I've added the description: **"Prevent undeclared variables in JSX"**  

- Fix Issue #19 