### PR TITLE
Adds import order convention using eslint-plugin-import/order rule

### DIFF
--- a/eslint-config-feedzai/package.json
+++ b/eslint-config-feedzai/package.json
@@ -31,10 +31,10 @@
   "devDependencies": {},
   "dependencies": {
     "eslint": "^5.10.0",
-    "eslint-plugin-import": "^2.14.0"
+    "eslint-plugin-import": "^2.17.2"
   },
   "peerDependencies": {
     "eslint": "^5.10.0",
-    "eslint-plugin-import": "^2.14.0"
+    "eslint-plugin-import": "^2.17.2"
   }
 }

--- a/eslint-config-feedzai/rules/style.js
+++ b/eslint-config-feedzai/rules/style.js
@@ -6,6 +6,10 @@
  */
 
 module.exports = {
+    plugins: [
+        "import"
+    ],
+
     rules: {
 
         // Enforce spaces
@@ -183,6 +187,19 @@ module.exports = {
 
         // Enforce the location of arrow function bodies with implicit returns
         // https://eslint.org/docs/rules/implicit-arrow-linebreak
-        "implicit-arrow-linebreak": ["error", "beside"]
+        "implicit-arrow-linebreak": ["error", "beside"],
+
+        // Enforce a convention in module import order
+        // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/order.md
+        "import/order": ["error", {
+            "groups": [
+                "builtin", // Built-in types are first
+                "external", // Then external modules
+                "internal", // Then internal modules
+                "parent", // Then parent types
+                "sibling", // Then sibling types
+                "index" // Then the index file
+            ]
+        }]
     }
 };


### PR DESCRIPTION
Currently, we do not have a modules import convention and sometimes it is hard to follow an import standard. So, I've updated the `eslint-plugin-import` version to 2.17.2 (**latest**) in order to use the `order` rule (see [docs](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/order.md)). I've also added the conventions that would make sense, but let's discuss them :smile:   